### PR TITLE
omit numerical package names

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "dependent-counts": "^2.0.0",
+    "is-number": "^4.0.0",
     "lodash": "^3.10.0",
     "ora": "^0.4.0",
     "package-stream": "^1.0.2",

--- a/script/build
+++ b/script/build
@@ -17,7 +17,7 @@ registry
 
 function addPackage (pkg) {
   const name = pkg.name
-  if (name && name.length && !names.includes(name)) names.push(name)
+  if (name && name.length) names.push(name)
 
   // to check the finish function early...
   // if (names.length > 100 * 1000) finish()
@@ -25,7 +25,12 @@ function addPackage (pkg) {
 
 function finish () {
   const filename = path.join(__dirname, '../names.json')
-  const finalNames = chain(names).compact().uniq().value()
+  const finalNames = chain(names)
+    .compact()
+    .uniq()
+    .value()
+    .filter(name => !isNumber(name))
+
   fs.writeFileSync(filename, JSON.stringify(finalNames, null, 2))
   console.log(`\nwrote ${finalNames.length} package names to ${filename}`)
   process.exit()

--- a/test/index.js
+++ b/test/index.js
@@ -4,5 +4,6 @@ const names = require('..')
 test('names', function (t) {
   t.ok(Array.isArray(names), 'is an array')
   t.ok(names.length > 260*1000, 'has hella names')
+  t.notOk(names.find(name => name === '69'), 'does not include numerical packages')
   t.end()
 })


### PR DESCRIPTION
This change omits packages with names like `69`, because they're probably all bunk, and things get screwy in JavaScript when you try use one of these package names as an object key.