### PR TITLE
Add .npmignore to restrict published files to only what is needed on install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+test
+script
+.github
+example.js
+package-lock.json


### PR DESCRIPTION
You can test by running `npm pack` then inspect the output tarball's content. Only the following files should be present:
* `cli.js`
* `names.json`
* `package.json`
* `readme.md`
